### PR TITLE
Resolve uninitialized values

### DIFF
--- a/memory_ext
+++ b/memory_ext
@@ -197,8 +197,8 @@ if ($ARGV[0] and $ARGV[0] eq "config")
 # Any optional value needs to be initialized to zero if it's used in a calculation below
 # and is has not been set by &fetch_meminfo
 
-$anon = $mems{'Active(anon)'} + $mems{'Inactive(anon)'};
-$file = $mems{'Active(file)'} + $mems{'Inactive(file)'};
+my $anon = $mems{'Active(anon)'} + $mems{'Inactive(anon)'};
+my $file = $mems{'Active(file)'} + $mems{'Inactive(file)'};
 
 print "anon.value ", $anon - $mems{'SwapCached'} - $mems{'Shmem'}, "\n";
 print "page_tables.value ", $mems{'PageTables'}, "\n";


### PR DESCRIPTION
to suppress the error like following:

```
2015/10/01-14:40:47 [7080] Error output from memory_ext:
2015/10/01-14:40:47 [7080]      Use of uninitialized value in addition (+) at /etc/munin/plugins/memory_ext line 200.
2015/10/01-14:40:47 [7080]      Use of uninitialized value in addition (+) at /etc/munin/plugins/memory_ext line 200.
2015/10/01-14:40:47 [7080]      Use of uninitialized value in addition (+) at /etc/munin/plugins/memory_ext line 201.
2015/10/01-14:40:47 [7080]      Use of uninitialized value in addition (+) at /etc/munin/plugins/memory_ext line 201.
2015/10/01-14:40:47 [7080]      Use of uninitialized value in subtraction (-) at /etc/munin/plugins/memory_ext line 203.
2015/10/01-14:40:47 [7080]      Use of uninitialized value in print at /etc/munin/plugins/memory_ext line 205.
2015/10/01-14:40:47 [7080]      Use of uninitialized value in print at /etc/munin/plugins/memory_ext line 207.
2015/10/01-14:40:47 [7080]      Use of uninitialized value in print at /etc/munin/plugins/memory_ext line 209.
2015/10/01-14:40:47 [7080]      Use of uninitialized value in print at /etc/munin/plugins/memory_ext line 210.
2015/10/01-14:40:47 [7080]      Use of uninitialized value in print at /etc/munin/plugins/memory_ext line 211.
```
